### PR TITLE
addresses issue https://github.com/tlienart/Xranklin.jl/issues/174

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FranklinParser"
 uuid = "796511e7-1510-466f-ad0c-1823c64bcafa"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-FranklinParser = "796511e7-1510-466f-ad0c-1823c64bcafa"
-SnoopCompile = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/test/misc_fixes.jl
+++ b/test/misc_fixes.jl
@@ -1,3 +1,24 @@
+# Dec12'22 | release line return deactivated in block find so that
+# other things can start immediately after e.g. a heading
+md = """
+    # abc
+    * i1
+    * i2
+    """
+g = FP.md_partition(md)
+@test g[1].name == :H1
+@test g[1].ss == "# abc\n"
+@test FP.content(g[1]) == " abc"
+@test g[2].name == :LIST
+@test g[2].ss == "\n* i1\n* i2"
+@test g[3].name == :P_BREAK
+md = """
+    @def v = 5
+    * i1
+    * i2
+    """
+g = FP.md_partition(md)
+@test g[2].ss == "\n* i1\n* i2"
 # Dec9'22 | remove_inner! when last block has from=to
 md = """
     * abc


### PR DESCRIPTION
Now:

```
# a
* i1
* i2
```

will lead to a list with two items. Before you'd have had to put an explicit line skip between the heading and the list. Same with `@def` (i.e. blocks ending with `:LINE_RETURN`). 